### PR TITLE
Disable passing --build for iPhoneSimulator

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -93,7 +93,7 @@ class Libxml2Conan(ConanFile):
                 else:
                     configure_args.extend(['--enable-static', '--disable-shared'])
 
-                # Disable --build when building for iPhoneSimulator. The configure script halts on 
+                # Disable --build when building for iPhoneSimulator. The configure script halts on
                 # not knowing if it should cross-compile.
                 build = None
                 if self.settings.os == "iOS" and self.settings.arch == "x86_64":

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,7 +92,14 @@ class Libxml2Conan(ConanFile):
                     configure_args.extend(['--enable-shared', '--disable-static'])
                 else:
                     configure_args.extend(['--enable-static', '--disable-shared'])
-                env_build.configure(args=configure_args)
+
+                # Disable --build when building for iPhoneSimulator. The configure script halts on 
+                # not knowing if it should cross-compile.
+                build = None
+                if self.settings.os == "iOS" and self.settings.arch == "x86_64":
+                    build = False
+                    
+                env_build.configure(args=configure_args,build=build)
                 env_build.make(args=["install"])
 
     def package(self):


### PR DESCRIPTION

Disable passing --build to the autotools for iPhoneSimulator, otherwise it gets stuck on not knowing whether it should cross-compile.

