### PR TITLE
fix call to tools.unix_path on non-windows environment

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -112,7 +112,7 @@ class Libxml2Conan(ConanFile):
         env_build = AutoToolsBuildEnvironment(self, win_bash=in_win)
         if not in_win:
             env_build.fpic = self.options.fPIC
-        full_install_subfolder = tools.unix_path(self.package_folder)
+        full_install_subfolder = tools.unix_path(self.package_folder) if in_win else self.package_folder
         with tools.environment_append(env_build.vars):
             with tools.chdir(self._source_subfolder):
                 # fix rpath


### PR DESCRIPTION
Hi!

`tools.unix_path` is a windows-only function.

When using case-sensitive paths in linux environment (for ex.), the call currently returns a lower-case path, implying wrong install path.

```bash
olliess@scoobi:~/Travail/workspace/Eurodecision/conan-libxml2/build$ conan build ..
conanfile.py (libxml2/2.9.9@None/None): Running build()
conanfile.py (libxml2/2.9.9@None/None): Calling:
 > ./configure '--with-python=no' '--prefix=/home/olliess/travail/workspace/eurodecision/conan-libxml2/build/package' '--with-pic' '--enable-static' '--disable-shared' '--with-zlib' '--without-lzma' '--with-iconv' '--without-icu' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libexecdir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/share' 
checking whether to enable maintainer-specific portions of Makefiles... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
# [log stripped]
make[3] : on entre dans le répertoire « /home/olliess/Travail/workspace/Eurodecision/conan-libxml2/build/source_subfolder »
/bin/mkdir -p /home/olliess/travail/workspace/eurodecision/conan-libxml2/build/package/share/doc/libxml2-2.9.9
 /bin/mkdir -p '/home/olliess/travail/workspace/eurodecision/conan-libxml2/build/package/bin'
 /bin/mkdir -p '/home/olliess/travail/workspace/eurodecision/conan-libxml2/build/package/lib'
 /bin/mkdir -p '/home/olliess/travail/workspace/eurodecision/conan-libxml2/build/package/lib/cmake/libxml2'
 /bin/mkdir -p '/home/olliess/travail/workspace/eurodecision/conan-libxml2/build/package/share/aclocal'
```

Note the `/home/olliess/Travail/workspace/Eurodecision/conan-libxml2/build` modified into `/home/olliess/travail/workspace/eurodecision/conan-libxml2/build`

I guess the same change has to be applied to the other version branches.

Please let me know if proposed commit should be improved.