### PR TITLE
fix source subfolder use in case of isolated sourcing

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -45,13 +45,14 @@ class Libxml2Conan(ConanFile):
     def _is_msvc(self):
         return self.settings.compiler == 'Visual Studio'
 
-    def full_source_subfolder(self):
+    @property
+    def _full_source_subfolder(self):
         return os.path.join(self.source_folder, self._source_subfolder)
 
     def source(self):
         tools.get("http://xmlsoft.org/sources/libxml2-{0}.tar.gz".format(self.version),
                   sha256="94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871")
-        os.rename("libxml2-{0}".format(self.version), self.full_source_subfolder())
+        os.rename("libxml2-{0}".format(self.version), self._source_subfolder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -67,7 +68,7 @@ class Libxml2Conan(ConanFile):
             self._build_with_configure()
 
     def _build_windows(self):
-        with tools.chdir(os.path.join(self.full_source_subfolder(), 'win32')):
+        with tools.chdir(os.path.join(self._full_source_subfolder, 'win32')):
             debug = "yes" if self.settings.build_type == "Debug" else "no"
             static = "no" if self.options.shared else "yes"
 
@@ -116,43 +117,41 @@ class Libxml2Conan(ConanFile):
         if not in_win:
             env_build.fpic = self.options.fPIC
         full_install_subfolder = tools.unix_path(self.package_folder) if in_win else self.package_folder
-        with tools.environment_append(env_build.vars):
-            with tools.chdir(self.full_source_subfolder()):
-                # fix rpath
-                if self.settings.os == "Macos":
-                    tools.replace_in_file("configure", r"-install_name \$rpath/", "-install_name ")
-                configure_args = ['--with-python=no', '--prefix=%s' % full_install_subfolder]
-                if env_build.fpic:
-                    configure_args.extend(['--with-pic'])
-                if self.options.shared:
-                    configure_args.extend(['--enable-shared', '--disable-static'])
-                else:
-                    configure_args.extend(['--enable-static', '--disable-shared'])
-                configure_args.extend(['--with-zlib' if self.options.zlib else '--without-zlib'])
-                configure_args.extend(['--with-lzma' if self.options.lzma else '--without-lzma'])
-                configure_args.extend(['--with-iconv' if self.options.iconv else '--without-iconv'])
-                configure_args.extend(['--with-icu' if self.options.icu else '--without-icu'])
+        # fix rpath
+        if self.settings.os == "Macos":
+            tools.replace_in_file("configure", r"-install_name \$rpath/", "-install_name ")
+        configure_args = ['--with-python=no', '--prefix=%s' % full_install_subfolder]
+        if env_build.fpic:
+            configure_args.extend(['--with-pic'])
+        if self.options.shared:
+            configure_args.extend(['--enable-shared', '--disable-static'])
+        else:
+            configure_args.extend(['--enable-static', '--disable-shared'])
+        configure_args.extend(['--with-zlib' if self.options.zlib else '--without-zlib'])
+        configure_args.extend(['--with-lzma' if self.options.lzma else '--without-lzma'])
+        configure_args.extend(['--with-iconv' if self.options.iconv else '--without-iconv'])
+        configure_args.extend(['--with-icu' if self.options.icu else '--without-icu'])
 
-                # Disable --build when building for iPhoneSimulator. The configure script halts on
-                # not knowing if it should cross-compile.
-                build = None
-                if self.settings.os == "iOS" and self.settings.arch == "x86_64":
-                    build = False
+        # Disable --build when building for iPhoneSimulator. The configure script halts on
+        # not knowing if it should cross-compile.
+        build = None
+        if self.settings.os == "iOS" and self.settings.arch == "x86_64":
+            build = False
 
-                env_build.configure(args=configure_args, build=build)
-                env_build.make(args=["install"])
+        env_build.configure(args=configure_args, build=build, configure_dir=self._full_source_subfolder)
+        env_build.make(args=["install"])
 
     def package(self):
         self.copy("FindLibXml2.cmake", ".", ".")
         # copy package license
-        self.copy("COPYING", src=self.full_source_subfolder(), dst="licenses", ignore_case=True, keep_path=False)
+        self.copy("COPYING", src=self._full_source_subfolder, dst="licenses", ignore_case=True, keep_path=False)
         if self.settings.os == "Windows":
             # There is no way to avoid building the tests, but at least we don't want them in the package
             for prefix in ["run", "test"]:
                 for test in glob.glob("%s/bin/%s*" % (self.package_folder, prefix)):
                     os.remove(test)
         for header in ["win32config.h", "wsockcompat.h"]:
-            self.copy(pattern=header, src=os.path.join(self.full_source_subfolder(), "include"),
+            self.copy(pattern=header, src=os.path.join(self._full_source_subfolder, "include"),
                       dst=os.path.join("include", "libxml2"), keep_path=False)
         if self._is_msvc:
             # remove redundant libraries to avoid confusion

--- a/conanfile.py
+++ b/conanfile.py
@@ -119,7 +119,7 @@ class Libxml2Conan(ConanFile):
         full_install_subfolder = tools.unix_path(self.package_folder) if in_win else self.package_folder
         # fix rpath
         if self.settings.os == "Macos":
-            tools.replace_in_file("configure", r"-install_name \$rpath/", "-install_name ")
+            tools.replace_in_file(os.path.join(self._full_source_subfolder, "configure"), r"-install_name \$rpath/", "-install_name ")
         configure_args = ['--with-python=no', '--prefix=%s' % full_install_subfolder]
         if env_build.fpic:
             configure_args.extend(['--with-pic'])


### PR DESCRIPTION
Hi!

In case of isolated test process (see Package development flow, https://docs.conan.io/en/latest/developing_packages/package_dev_flow.html) the _source_subfolder used for extracting the libxml2 archive has to be relocated according to the source_folder.

Proposed commit introduces a function to wrap the path build. Not sure if the path modification could be done in some Conanfile step.

Please let me know if any improvment should be made to the proposed PR.